### PR TITLE
Renamings

### DIFF
--- a/graph/api/src/main/scala/org/apache/spark/graph/api/CypherResult.scala
+++ b/graph/api/src/main/scala/org/apache/spark/graph/api/CypherResult.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.graph.api
 
+import org.apache.spark.annotation.Evolving
 import org.apache.spark.sql.{Dataset, Row}
 
 /**
@@ -26,6 +27,7 @@ import org.apache.spark.sql.{Dataset, Row}
  *
  * @since 3.0.0
  */
+@Evolving
 sealed trait CypherResult {
   // Note that representing the CypherResult as a trait allows for future extensions
   // (e.g. returning graphs in addition to tables).

--- a/graph/api/src/main/scala/org/apache/spark/graph/api/GraphElementDataset.scala
+++ b/graph/api/src/main/scala/org/apache/spark/graph/api/GraphElementDataset.scala
@@ -17,17 +17,17 @@
 
 package org.apache.spark.graph.api
 
+import org.apache.spark.annotation.Evolving
 import org.apache.spark.sql.{Dataset, Row}
 
 /**
- * A [[PropertyGraph]] is created from GraphElementFrames.
- *
- * A graph element is either a node or a relationship.
- * A GraphElementFrame wraps a Dataset and describes how it maps to graph elements.
+ * A [[PropertyGraph]] whose graph element is either a node or a relationship.
+ * A GraphElementDataset wraps a Dataset and describes how it maps to graph elements.
  *
  * @since 3.0.0
  */
-abstract class GraphElementFrame {
+@Evolving
+abstract class GraphElementDataset {
 
   /**
    * Initial Dataset that can still contain unmapped, arbitrarily ordered columns.

--- a/graph/api/src/main/scala/org/apache/spark/graph/api/NodeDataset.scala
+++ b/graph/api/src/main/scala/org/apache/spark/graph/api/NodeDataset.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.graph.api
 
+import org.apache.spark.annotation.Evolving
 import org.apache.spark.sql.{Dataset, Row}
 
 /**
@@ -31,9 +32,10 @@ import org.apache.spark.sql.{Dataset, Row}
  * @param properties mapping from property keys to corresponding columns
  * @since 3.0.0
  */
-case class NodeFrame private[graph](
+@Evolving
+case class NodeDataset private[graph](
     ds: Dataset[Row],
     idColumn: String,
     labelSet: Set[String],
     properties: Map[String, String])
-  extends GraphElementFrame
+  extends GraphElementDataset

--- a/graph/api/src/main/scala/org/apache/spark/graph/api/NodeDatasetBuilder.scala
+++ b/graph/api/src/main/scala/org/apache/spark/graph/api/NodeDatasetBuilder.scala
@@ -19,15 +19,17 @@ package org.apache.spark.graph.api
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.annotation.Evolving
 import org.apache.spark.sql.{Dataset, Row}
 
 /**
- * Interface used to build a [[NodeFrame]].
+ * A builder for [[NodeDataset]].
  *
  * @param ds Dataset containing a single node in each row
  * @since 3.0.0
  */
-final class NodeFrameBuilder(var ds: Dataset[Row]) {
+@Evolving
+final class NodeDatasetBuilder(val ds: Dataset[Row]) {
 
   private var idColumn: String = CypherSession.ID_COLUMN
   private var labelSet: Set[String] = Set.empty
@@ -37,7 +39,7 @@ final class NodeFrameBuilder(var ds: Dataset[Row]) {
    * @param idColumn column that contains the node identifier
    * @since 3.0.0
    */
-  def idColumn(idColumn: String): NodeFrameBuilder = {
+  def idColumn(idColumn: String): NodeDatasetBuilder = {
     if (idColumn.isEmpty) {
       throw new IllegalArgumentException("idColumn must not be empty")
     }
@@ -49,7 +51,7 @@ final class NodeFrameBuilder(var ds: Dataset[Row]) {
    * @param labelSet labels that are assigned to all nodes
    * @since 3.0.0
    */
-  def labelSet(labelSet: Array[String]): NodeFrameBuilder = {
+  def labelSet(labelSet: Array[String]): NodeDatasetBuilder = {
     this.labelSet = labelSet.toSet
     this
   }
@@ -58,7 +60,7 @@ final class NodeFrameBuilder(var ds: Dataset[Row]) {
    * @param properties mapping from property keys to corresponding columns
    * @since 3.0.0
    */
-  def properties(properties: Map[String, String]): NodeFrameBuilder = {
+  def properties(properties: Map[String, String]): NodeDatasetBuilder = {
     this.properties = properties
     this
   }
@@ -67,18 +69,18 @@ final class NodeFrameBuilder(var ds: Dataset[Row]) {
    * @param properties mapping from property keys to corresponding columns
    * @since 3.0.0
    */
-  def properties(properties: java.util.Map[String, String]): NodeFrameBuilder = {
+  def properties(properties: java.util.Map[String, String]): NodeDatasetBuilder = {
     this.properties = properties.asScala.toMap
     this
   }
 
   /**
-   * Creates a `NodeFrame` from the specified builder parameters.
+   * Creates a `NodeDataset` from the specified builder parameters.
    *
    * @since 3.0.0
    */
-  def build(): NodeFrame = {
-    NodeFrame(ds, idColumn, labelSet, properties)
+  def build(): NodeDataset = {
+    NodeDataset(ds, idColumn, labelSet, properties)
   }
 
 }

--- a/graph/api/src/main/scala/org/apache/spark/graph/api/PropertyGraph.scala
+++ b/graph/api/src/main/scala/org/apache/spark/graph/api/PropertyGraph.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.graph.api
 
+import org.apache.spark.annotation.Evolving
 import org.apache.spark.sql.{Dataset, Row}
 
 /**
@@ -29,6 +30,7 @@ import org.apache.spark.sql.{Dataset, Row}
  * @see <a href="https://dl.acm.org/citation.cfm?id=3183713.3190657">Property Graph Model</a>
  * @since 3.0.0
  */
+@Evolving
 abstract class PropertyGraph {
 
   /**
@@ -77,22 +79,22 @@ abstract class PropertyGraph {
     cypherSession.cypher(this, query, parameters)
 
   /**
-   * Returns the [[NodeFrame]] for a given node label set.
+   * Returns the [[NodeDataset]] for a given node label set.
    *
-   * @param labelSet Label set used for NodeFrame lookup
-   * @return NodeFrame for the given label set
+   * @param labelSet Label set used for NodeDataset lookup
+   * @return NodeDataset for the given label set
    * @since 3.0.0
    */
-  def nodeFrame(labelSet: Array[String]): NodeFrame
+  def nodeDataset(labelSet: Array[String]): NodeDataset
 
   /**
-   * Returns the [[RelationshipFrame]] for a given relationship type.
+   * Returns the [[RelationshipDataset]] for a given relationship type.
    *
-   * @param relationshipType Relationship type used for RelationshipFrame lookup
-   * @return RelationshipFrame for the given relationship type
+   * @param relationshipType Relationship type used for RelationshipDataset lookup
+   * @return RelationshipDataset for the given relationship type
    * @since 3.0.0
    */
-  def relationshipFrame(relationshipType: String): RelationshipFrame
+  def relationshipDataset(relationshipType: String): RelationshipDataset
 
   /**
    * Returns a Dataset that contains a row for each node in this graph.

--- a/graph/api/src/main/scala/org/apache/spark/graph/api/PropertyGraphReader.scala
+++ b/graph/api/src/main/scala/org/apache/spark/graph/api/PropertyGraphReader.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.graph.api
 
+import org.apache.spark.annotation.Evolving
+
+@Evolving
 abstract class PropertyGraphReader(session: CypherSession) {
 
   protected var format: String =

--- a/graph/api/src/main/scala/org/apache/spark/graph/api/PropertyGraphType.scala
+++ b/graph/api/src/main/scala/org/apache/spark/graph/api/PropertyGraphType.scala
@@ -17,11 +17,14 @@
 
 package org.apache.spark.graph.api
 
+import org.apache.spark.annotation.Evolving
+
 /**
  * Describes the structure of a [[PropertyGraph]].
  *
  * @since 3.0.0
  */
+@Evolving
 trait PropertyGraphType {
 
   /**

--- a/graph/api/src/main/scala/org/apache/spark/graph/api/PropertyGraphWriter.scala
+++ b/graph/api/src/main/scala/org/apache/spark/graph/api/PropertyGraphWriter.scala
@@ -19,8 +19,10 @@ package org.apache.spark.graph.api
 
 import java.util.Locale
 
+import org.apache.spark.annotation.Evolving
 import org.apache.spark.sql.SaveMode
 
+@Evolving
 abstract class PropertyGraphWriter(val graph: PropertyGraph) {
 
   protected var saveMode: SaveMode = SaveMode.ErrorIfExists

--- a/graph/api/src/main/scala/org/apache/spark/graph/api/RelationshipDataset.scala
+++ b/graph/api/src/main/scala/org/apache/spark/graph/api/RelationshipDataset.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.graph.api
 
+import org.apache.spark.annotation.Evolving
 import org.apache.spark.sql.{Dataset, Row}
 
 /**
@@ -32,14 +33,15 @@ import org.apache.spark.sql.{Dataset, Row}
  * @param properties       mapping from property keys to corresponding columns
  * @since 3.0.0
  */
-case class RelationshipFrame private[graph] (
+@Evolving
+case class RelationshipDataset private[graph](
     ds: Dataset[Row],
     idColumn: String,
     sourceIdColumn: String,
     targetIdColumn: String,
     relationshipType: String,
     properties: Map[String, String])
-  extends GraphElementFrame {
+  extends GraphElementDataset {
 
   override def idColumns: Seq[String] = Seq(idColumn, sourceIdColumn, targetIdColumn)
 

--- a/graph/api/src/main/scala/org/apache/spark/graph/api/RelationshipDatasetBuilder.scala
+++ b/graph/api/src/main/scala/org/apache/spark/graph/api/RelationshipDatasetBuilder.scala
@@ -19,15 +19,17 @@ package org.apache.spark.graph.api
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.annotation.Evolving
 import org.apache.spark.sql.{Dataset, Row}
 
 /**
- * Interface used to build a [[RelationshipFrame]].
+ * A builder for [[RelationshipDataset]].
  *
  * @param ds Dataset containing a single relationship in each row
  * @since 3.0.0
  */
-final class RelationshipFrameBuilder(val ds: Dataset[Row]) {
+@Evolving
+final class RelationshipDatasetBuilder(val ds: Dataset[Row]) {
 
   private var idColumn: String = CypherSession.ID_COLUMN
   private var sourceIdColumn: String = CypherSession.SOURCE_ID_COLUMN
@@ -39,7 +41,7 @@ final class RelationshipFrameBuilder(val ds: Dataset[Row]) {
    * @param idColumn column that contains the relationship identifier
    * @since 3.0.0
    */
-  def idColumn(idColumn: String): RelationshipFrameBuilder = {
+  def idColumn(idColumn: String): RelationshipDatasetBuilder = {
     if (idColumn.isEmpty) {
       throw new IllegalArgumentException("idColumn must not be empty")
     }
@@ -51,7 +53,7 @@ final class RelationshipFrameBuilder(val ds: Dataset[Row]) {
    * @param sourceIdColumn column that contains the source node identifier of the relationship
    * @since 3.0.0
    */
-  def sourceIdColumn(sourceIdColumn: String): RelationshipFrameBuilder = {
+  def sourceIdColumn(sourceIdColumn: String): RelationshipDatasetBuilder = {
     if (sourceIdColumn.isEmpty) {
       throw new IllegalArgumentException("sourceIdColumn must not be empty")
     }
@@ -63,7 +65,7 @@ final class RelationshipFrameBuilder(val ds: Dataset[Row]) {
    * @param targetIdColumn column that contains the target node identifier of the relationship
    * @since 3.0.0
    */
-  def targetIdColumn(targetIdColumn: String): RelationshipFrameBuilder = {
+  def targetIdColumn(targetIdColumn: String): RelationshipDatasetBuilder = {
     if (targetIdColumn.isEmpty) {
       throw new IllegalArgumentException("targetIdColumn must not be empty")
     }
@@ -75,7 +77,7 @@ final class RelationshipFrameBuilder(val ds: Dataset[Row]) {
    * @param relationshipType relationship type that is assigned to all relationships
    * @since 3.0.0
    */
-  def relationshipType(relationshipType: String): RelationshipFrameBuilder = {
+  def relationshipType(relationshipType: String): RelationshipDatasetBuilder = {
     if (relationshipType.isEmpty) {
       throw new IllegalArgumentException("Relationship type must not be empty")
     }
@@ -87,7 +89,7 @@ final class RelationshipFrameBuilder(val ds: Dataset[Row]) {
    * @param properties mapping from property keys to corresponding columns
    * @since 3.0.0
    */
-  def properties(properties: Map[String, String]): RelationshipFrameBuilder = {
+  def properties(properties: Map[String, String]): RelationshipDatasetBuilder = {
     this.properties = properties
     this
   }
@@ -96,20 +98,20 @@ final class RelationshipFrameBuilder(val ds: Dataset[Row]) {
    * @param properties mapping from property keys to corresponding columns
    * @since 3.0.0
    */
-  def properties(properties: java.util.Map[String, String]): RelationshipFrameBuilder = {
+  def properties(properties: java.util.Map[String, String]): RelationshipDatasetBuilder = {
     this.properties = properties.asScala.toMap
     this
   }
 
   /**
-   * Creates a [[RelationshipFrame]] from the specified builder parameters.
+   * Creates a [[RelationshipDataset]] from the specified builder parameters.
    *
    * @since 3.0.0
    */
-  def build(): RelationshipFrame = {
+  def build(): RelationshipDataset = {
     maybeRelationshipType match {
       case Some(relType) =>
-        RelationshipFrame(ds, idColumn, sourceIdColumn, targetIdColumn, relType, properties)
+        RelationshipDataset(ds, idColumn, sourceIdColumn, targetIdColumn, relType, properties)
       case None => throw new IllegalArgumentException("Relationship type must be set.")
     }
   }

--- a/graph/api/src/test/java/org/apache/spark/graph/api/JavaPropertyGraphSuite.java
+++ b/graph/api/src/test/java/org/apache/spark/graph/api/JavaPropertyGraphSuite.java
@@ -64,7 +64,7 @@ public abstract class JavaPropertyGraphSuite implements Serializable {
   }
 
   @Test
-  public void testCreateFromNodeFrame() {
+  public void testCreateFromNodeDataset() {
     StructType personSchema = createSchema(
       Lists.newArrayList("id", "name"),
       Lists.newArrayList(LongType, StringType));
@@ -80,14 +80,14 @@ public abstract class JavaPropertyGraphSuite implements Serializable {
     List<Row> knowsData = Collections.singletonList(RowFactory.create(0L, 0L, 1L, 1984));
 
     Dataset<Row> personDf = spark.createDataFrame(personData, personSchema);
-    NodeFrame personNodeFrame = cypherSession.buildNodeFrame(personDf)
+    NodeDataset personNodeDataset = cypherSession.buildNodeDataset(personDf)
       .idColumn("id")
       .labelSet(new String[]{"Person"})
       .properties(Collections.singletonMap("name", "name"))
       .build();
 
     Dataset<Row> knowsDf = spark.createDataFrame(knowsData, knowsSchema);
-    RelationshipFrame knowsRelFrame = cypherSession.buildRelationshipFrame(knowsDf)
+    RelationshipDataset knowsRelDataset = cypherSession.buildRelationshipDataset(knowsDf)
       .idColumn("id")
       .sourceIdColumn("source")
       .targetIdColumn("target")
@@ -97,8 +97,8 @@ public abstract class JavaPropertyGraphSuite implements Serializable {
 
 
     PropertyGraph graph = cypherSession.createGraph(
-      new NodeFrame[]{personNodeFrame},
-      new RelationshipFrame[]{knowsRelFrame});
+      new NodeDataset[]{personNodeDataset},
+      new RelationshipDataset[]{knowsRelDataset});
     List<Row> result = graph.nodes().collectAsList();
     Assert.assertEquals(2, result.size());
   }

--- a/graph/api/src/test/scala/org/apache/spark/graph/api/CypherSessionSuite.scala
+++ b/graph/api/src/test/scala/org/apache/spark/graph/api/CypherSessionSuite.scala
@@ -28,7 +28,7 @@ abstract class CypherSessionSuite extends QueryTest with SharedSparkSession with
 
   test("save and loads a property graph") {
     val nodeData = spark.createDataFrame(Seq(0L -> "Alice", 1L -> "Bob")).toDF("id", "name")
-    val nodeFrame = cypherSession.buildNodeFrame(nodeData)
+    val nodeDataset = cypherSession.buildNodeDataset(nodeData)
       .idColumn("id")
       .labelSet(Array("Person"))
       .properties(Map("name" -> "name"))
@@ -37,14 +37,14 @@ abstract class CypherSessionSuite extends QueryTest with SharedSparkSession with
     val relationshipData = spark
       .createDataFrame(Seq((0L, 0L, 1L, 1984)))
       .toDF("id", "source", "target", "since")
-    val relationshipFrame = cypherSession.buildRelationshipFrame(relationshipData)
+    val relationshipDataset = cypherSession.buildRelationshipDataset(relationshipData)
       .idColumn("id")
       .sourceIdColumn("source")
       .targetIdColumn("target")
       .relationshipType("KNOWS")
       .build()
 
-    val writeGraph = cypherSession.createGraph(Array(nodeFrame), Array(relationshipFrame))
+    val writeGraph = cypherSession.createGraph(Array(nodeDataset), Array(relationshipDataset))
 
     withTempDir(file => {
       writeGraph.write.mode(SaveMode.Overwrite).save(file.getAbsolutePath)

--- a/graph/api/src/test/scala/org/apache/spark/graph/api/PropertyGraphSuite.scala
+++ b/graph/api/src/test/scala/org/apache/spark/graph/api/PropertyGraphSuite.scala
@@ -71,14 +71,14 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
         (8L, 2L, 5L, false, true)))
     .toDF(ID_COLUMN, SOURCE_ID_COLUMN, TARGET_ID_COLUMN, label("KNOWS"), label("STUDY_AT"))
 
-  test("create graph from NodeFrame") {
+  test("create graph from NodeDataset") {
     val nodeData = spark.createDataFrame(Seq(0L -> "Alice", 1L -> "Bob")).toDF("id", "name")
-    val nodeFrame = cypherSession.buildNodeFrame(nodeData)
+    val nodeDataset = cypherSession.buildNodeDataset(nodeData)
       .idColumn("id")
       .labelSet(Array("Person"))
       .properties(Map("name" -> "name"))
       .build()
-    val graph = cypherSession.createGraph(Array(nodeFrame), Array.empty[RelationshipFrame])
+    val graph = cypherSession.createGraph(Array(nodeDataset), Array.empty[RelationshipDataset])
 
     val expectedDf = spark
       .createDataFrame(Seq((convertId(0L), true, "Alice"), (convertId(1L), true, "Bob")))
@@ -87,9 +87,9 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
     checkAnswer(graph.nodes, expectedDf)
   }
 
-  test("create graph from NodeFrame and RelationshipFrame") {
+  test("create graph from NodeDataset and RelationshipDataset") {
     val nodeData = spark.createDataFrame(Seq(0L -> "Alice", 1L -> "Bob")).toDF("id", "name")
-    val nodeFrame = cypherSession.buildNodeFrame(nodeData)
+    val nodeDataset = cypherSession.buildNodeDataset(nodeData)
       .idColumn("id")
       .labelSet(Array("Person"))
       .properties(Map("name" -> "name"))
@@ -97,7 +97,7 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
     val relationshipData = spark
       .createDataFrame(Seq((0L, 0L, 1L, 1984)))
       .toDF("id", "source", "target", "since")
-    val relationshipFrame = cypherSession.buildRelationshipFrame(relationshipData)
+    val relationshipDataset = cypherSession.buildRelationshipDataset(relationshipData)
       .idColumn("id")
       .sourceIdColumn("source")
       .targetIdColumn("target")
@@ -105,7 +105,7 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
       .properties(Map("since" -> "since"))
       .build()
 
-    val graph = cypherSession.createGraph(Array(nodeFrame), Array(relationshipFrame))
+    val graph = cypherSession.createGraph(Array(nodeDataset), Array(relationshipDataset))
 
     val expectedNodeDf = spark
       .createDataFrame(Seq((convertId(0L), true, "Alice"), (convertId(1L), true, "Bob")))
@@ -127,13 +127,13 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
       .createDataFrame(Seq((2L, "Eve", "CS")))
       .toDF("id", "name", "subject")
 
-    val studentNF = cypherSession.buildNodeFrame(studentDF)
+    val studentNodeDataset = cypherSession.buildNodeDataset(studentDF)
         .idColumn("id")
         .labelSet(Array("Person", "Student"))
         .properties(Map("name" -> "name", "age" -> "age"))
         .build()
 
-    val teacherNF = cypherSession.buildNodeFrame(teacherDF)
+    val teacherNodeDataset = cypherSession.buildNodeDataset(teacherDF)
       .idColumn("id")
       .labelSet(Array("Person", "Teacher"))
       .properties(Map("name" -> "name", "subject" -> "subject"))
@@ -146,21 +146,23 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
       .createDataFrame(Seq((1L, 2L, 1L)))
       .toDF("id", "source", "target")
 
-    val knowsRF = cypherSession.buildRelationshipFrame(knowsDF)
+    val knowsRelationshipDataset = cypherSession.buildRelationshipDataset(knowsDF)
       .idColumn("id")
       .sourceIdColumn("source")
       .targetIdColumn("target")
       .relationshipType("KNOWS")
       .properties(Map("since" -> "since"))
       .build()
-    val teachesRF = cypherSession.buildRelationshipFrame(teachesDF)
+    val teachesRelationshipDataset = cypherSession.buildRelationshipDataset(teachesDF)
       .idColumn("id")
       .sourceIdColumn("source")
       .targetIdColumn("target")
       .relationshipType("TEACHES")
       .build()
 
-    val graph = cypherSession.createGraph(Array(studentNF, teacherNF), Array(knowsRF, teachesRF))
+    val graph = cypherSession.createGraph(
+      Array(studentNodeDataset, teacherNodeDataset),
+      Array(knowsRelationshipDataset, teachesRelationshipDataset))
 
     val expectedNodeDf = spark
       .createDataFrame(
@@ -202,12 +204,12 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
       .createDataFrame(Seq((2L, "Eve", "CS")))
       .toDF("id", "col_name", "col_subject")
 
-    val studentNF = NodeFrame(
+    val studentNodeDataset = NodeDataset(
       studentDF,
       "id",
       Set("Person", "Student"),
       properties = Map("name" -> "col_name", "age" -> "col_age"))
-    val teacherNF = NodeFrame(
+    val teacherNodeDataset = NodeDataset(
       teacherDF,
       "id",
       Set("Person", "Teacher"),
@@ -218,14 +220,14 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
       .toDF("id", "source", "target", "col_since")
     val teachesDF = spark.createDataFrame(Seq((1L, 2L, 1L))).toDF("id", "source", "target")
 
-    val knowsRF = RelationshipFrame(
+    val knowsRelationshipDataset = RelationshipDataset(
       knowsDF,
       "id",
       "source",
       "target",
       relationshipType = "KNOWS",
       properties = Map("since" -> "col_since"))
-    val teachesRF = RelationshipFrame(
+    val teachesRelationshipDataset = RelationshipDataset(
       teachesDF,
       "id",
       "source",
@@ -233,7 +235,9 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
       "TEACHES",
       Map.empty)
 
-    val graph = cypherSession.createGraph(Array(studentNF, teacherNF), Array(knowsRF, teachesRF))
+    val graph = cypherSession.createGraph(
+      Array(studentNodeDataset, teacherNodeDataset),
+      Array(knowsRelationshipDataset, teachesRelationshipDataset))
 
     val expectedNodeDf = spark
       .createDataFrame(
@@ -269,11 +273,11 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
 
   test("select nodes via label set") {
     val graph = cypherSession.createGraph(nodes, relationships)
-    val nodeFrame = graph.nodeFrame(Array("Person", "Teacher"))
+    val nodeDataset = graph.nodeDataset(Array("Person", "Teacher"))
 
-    nodeFrame.labelSet shouldEqual Set("Person", "Teacher")
-    nodeFrame.idColumn shouldEqual ID_COLUMN
-    nodeFrame.properties shouldEqual Map(
+    nodeDataset.labelSet shouldEqual Set("Person", "Teacher")
+    nodeDataset.idColumn shouldEqual ID_COLUMN
+    nodeDataset.properties shouldEqual Map(
       "age" -> "age",
       "name" -> "name",
       "subject" -> "subject",
@@ -284,18 +288,18 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
         Seq((convertId(2L), Some(22), Some("Carol"), Some("CS"), None: Option[String])))
       .toDF(ID_COLUMN, "age", "name", "subject", "title")
 
-    checkAnswer(nodeFrame.ds, expectedNodeDf)
+    checkAnswer(nodeDataset.ds, expectedNodeDf)
   }
 
   test("select relationships via type") {
     val graph = cypherSession.createGraph(nodes, relationships)
-    val relationshipFrame = graph.relationshipFrame("KNOWS")
+    val relationshipDataset = graph.relationshipDataset("KNOWS")
 
-    relationshipFrame.relationshipType shouldEqual "KNOWS"
-    relationshipFrame.idColumn shouldEqual ID_COLUMN
-    relationshipFrame.sourceIdColumn shouldEqual SOURCE_ID_COLUMN
-    relationshipFrame.targetIdColumn shouldEqual TARGET_ID_COLUMN
-    relationshipFrame.properties shouldBe empty
+    relationshipDataset.relationshipType shouldEqual "KNOWS"
+    relationshipDataset.idColumn shouldEqual ID_COLUMN
+    relationshipDataset.sourceIdColumn shouldEqual SOURCE_ID_COLUMN
+    relationshipDataset.targetIdColumn shouldEqual TARGET_ID_COLUMN
+    relationshipDataset.properties shouldBe empty
 
     val expectedRelDf = spark
       .createDataFrame(
@@ -307,7 +311,7 @@ abstract class PropertyGraphSuite extends QueryTest with SharedSparkSession with
           (convertId(4L), convertId(3L), convertId(1L))))
       .toDF(ID_COLUMN, SOURCE_ID_COLUMN, TARGET_ID_COLUMN)
 
-    checkAnswer(relationshipFrame.ds, expectedRelDf)
+    checkAnswer(relationshipDataset.ds, expectedRelDf)
   }
 
   private def label(label: String): String = s"$LABEL_COLUMN_PREFIX$label"


### PR DESCRIPTION
This PR contains the following updates.
- Add `@Evolving` to all new classes in `api` package.
- Rename `GraphElementFrame` to `GraphElementDataset`
- Rename `NodeFrame` => `NodeDataset`
- Rename `NodeFrameBuilder` => `NodeDatasetBuilder`
- Rename `RelationshipFrame` => `RelationshipDataset`
- Rename `RelationshipFrameBuilder` => `RelationshipDatasetBuilder`
- All methods names and comments are updated accordingly.
- Change `var ds` to `val ds`
```
-final class NodeDatasetBuilder(var ds: Dataset[Row]) {
+final class NodeDatasetBuilder(val ds: Dataset[Row]) {
```